### PR TITLE
#12 add error handling

### DIFF
--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="phpstan" version="1.10.21" installed="1.10.21" location="./tools/phpstan" copy="false"/>
-  <phar name="psalm" version="5.13.0" installed="5.13.0" location="./tools/psalm" copy="false"/>
+  <phar name="phpstan" version="1.12.3" installed="1.12.3" location="./tools/phpstan" copy="false"/>
+  <phar name="psalm" version="5.26.1" installed="5.26.1" location="./tools/psalm" copy="false"/>
 </phive>

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
     },
     "require-dev": {
         "cakephp/cakephp-codesniffer": "^5.0",
+        "mockery/mockery": "^1.6",
         "phpunit/phpunit": "^10.5.5 || ^11.1.3"
     },
     "license": "MIT",

--- a/src/Error/SchedulerStoppedException.php
+++ b/src/Error/SchedulerStoppedException.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+namespace CakeScheduler\Error;
+
+use RuntimeException;
+
+class SchedulerStoppedException extends RuntimeException
+{
+}

--- a/src/Scheduler/Scheduler.php
+++ b/src/Scheduler/Scheduler.php
@@ -34,6 +34,11 @@ class Scheduler implements EventDispatcherInterface
     protected CollectionInterface $events;
 
     /**
+     * The event code if execution should be stopped
+     */
+    public const SHOULD_STOP_EXECUTION = 1;
+
+    /**
      * @param \Cake\Core\Container|null $container The DI container instance from the app
      */
     public function __construct(?Container $container = null)

--- a/tests/TestCase/Command/ScheduleRunCommandTest.php
+++ b/tests/TestCase/Command/ScheduleRunCommandTest.php
@@ -4,16 +4,28 @@ declare(strict_types=1);
 namespace CakeScheduler\Test\TestCase\Command;
 
 use Cake\Collection\Collection;
+use Cake\Console\Arguments;
+use Cake\Console\ConsoleIo;
 use Cake\Console\TestSuite\ConsoleIntegrationTestTrait;
+use Cake\Core\Container;
+use Cake\Event\EventInterface;
+use Cake\TestSuite\LogTestTrait;
 use Cake\TestSuite\TestCase;
+use CakeScheduler\Error\SchedulerStoppedException;
 use CakeScheduler\Scheduler\Event;
 use CakeScheduler\Scheduler\Scheduler;
+use Exception;
+use Mockery;
+use Mockery\LegacyMockInterface;
 use TestApp\Command\TestAppCommand;
 use TestPlugin\Command\TestPluginCommand;
 
 class ScheduleRunCommandTest extends TestCase
 {
     use ConsoleIntegrationTestTrait;
+    use LogTestTrait;
+
+    protected Scheduler|LegacyMockInterface $scheduler;
 
     protected function setUp(): void
     {
@@ -24,19 +36,17 @@ class ScheduleRunCommandTest extends TestCase
             'TestApp\Application',
             [PLUGIN_TESTS . 'test_app' . DS . 'config']
         );
+
+        $this->scheduler = Mockery::mock(Scheduler::class, [new Container()])->makePartial();
     }
 
     public function testRunNoCommand(): void
     {
         $this->mockService(Scheduler::class, function () {
-            $schedulerMock = $this->getMockBuilder(Scheduler::class)->getMock();
-            $collection = new Collection([]);
+            $this->scheduler->shouldReceive('dueEvents')
+                ->andReturn(new Collection([]));
 
-            $schedulerMock->expects($this->any())
-                ->method('dueEvents')
-                ->willReturn($collection);
-
-            return $schedulerMock;
+            return $this->scheduler;
         });
         $this->exec('schedule:run');
 
@@ -47,16 +57,12 @@ class ScheduleRunCommandTest extends TestCase
     public function testRunSingleCommand(): void
     {
         $this->mockService(Scheduler::class, function () {
-            $schedulerMock = $this->getMockBuilder(Scheduler::class)->getMock();
-
             $event = new Event(new TestAppCommand(), []);
             $collection = new Collection([$event]);
+            $this->scheduler->shouldReceive('dueEvents')
+                ->andReturn($collection);
 
-            $schedulerMock->expects($this->any())
-                ->method('dueEvents')
-                ->willReturn($collection);
-
-            return $schedulerMock;
+            return $this->scheduler;
         });
         $this->exec('schedule:run');
 
@@ -68,17 +74,14 @@ class ScheduleRunCommandTest extends TestCase
     public function testRunMultipleCommands(): void
     {
         $this->mockService(Scheduler::class, function () {
-            $schedulerMock = $this->getMockBuilder(Scheduler::class)->getMock();
-
             $appEvent = new Event(new TestAppCommand(), []);
             $pluginEvent = new Event(new TestPluginCommand(), []);
             $collection = new Collection([$appEvent, $pluginEvent]);
 
-            $schedulerMock->expects($this->any())
-                ->method('dueEvents')
-                ->willReturn($collection);
+            $this->scheduler->shouldReceive('dueEvents')
+                ->andReturn($collection);
 
-            return $schedulerMock;
+            return $this->scheduler;
         });
         $this->exec('schedule:run');
 
@@ -92,16 +95,13 @@ class ScheduleRunCommandTest extends TestCase
     public function testRunSingleCommandWithArgsAndOptions(): void
     {
         $this->mockService(Scheduler::class, function () {
-            $schedulerMock = $this->getMockBuilder(Scheduler::class)->getMock();
-
             $event = new Event(new TestAppCommand(), ['somearg', '--myoption=someoption']);
             $collection = new Collection([$event]);
 
-            $schedulerMock->expects($this->any())
-                ->method('dueEvents')
-                ->willReturn($collection);
+            $this->scheduler->shouldReceive('dueEvents')
+                ->andReturn($collection);
 
-            return $schedulerMock;
+            return $this->scheduler;
         });
         $this->exec('schedule:run');
 
@@ -110,5 +110,125 @@ class ScheduleRunCommandTest extends TestCase
         $this->assertOutputContains('Test App Command executed');
         $this->assertOutputContains('with arg somearg');
         $this->assertOutputContains('with option someoption');
+    }
+
+    public function testRunSingleCommandWhichThrowsException(): void
+    {
+        $this->mockService(Scheduler::class, function () {
+            $command = new class () extends TestAppCommand {
+                public function execute(Arguments $args, ConsoleIo $io): void
+                {
+                    throw new Exception('Test Exception');
+                }
+            };
+
+            $event = new Event($command, []);
+            $collection = new Collection([$event]);
+
+            $this->scheduler->shouldReceive('dueEvents')
+                ->andReturn($collection);
+
+            return $this->scheduler;
+        });
+        $this->exec('schedule:run');
+
+        $this->assertExitSuccess();
+        $this->assertOutputContains('Executing [TestApp\\Command\\TestAppCommand@anonymous');
+        $this->assertErrorContains('Test Exception');
+    }
+
+    public function testRunSingleCommandWhichThrowsExceptionAndListenerStopsExecution(): void
+    {
+        $this->mockService(Scheduler::class, function () {
+            $command = new class () extends TestAppCommand {
+                public function execute(Arguments $args, ConsoleIo $io): void
+                {
+                    throw new Exception('Test Exception');
+                }
+            };
+
+            $event = new Event($command, []);
+            $collection = new Collection([$event]);
+
+            $this->scheduler->shouldReceive('dueEvents')
+                ->andReturn($collection);
+
+            $this->scheduler->getEventManager()->on('CakeScheduler.errorExecute', function (EventInterface $event) {
+                $event->setResult(Scheduler::SHOULD_STOP_EXECUTION);
+            });
+
+            return $this->scheduler;
+        });
+
+        $this->expectException(SchedulerStoppedException::class);
+        $this->expectExceptionMessage('Scheduler was stopped by event listener');
+        $this->exec('schedule:run');
+    }
+
+    public function testRunMultipleCommandsAndLastOneFails(): void
+    {
+        $this->mockService(Scheduler::class, function () {
+            $appEvent = new Event(new TestAppCommand(), []);
+            $pluginEvent = new Event(new TestPluginCommand(), []);
+            $failCommand = new class () extends TestAppCommand {
+                public function execute(Arguments $args, ConsoleIo $io): void
+                {
+                    throw new Exception('Test Exception');
+                }
+            };
+            $failEvent = new Event($failCommand, []);
+            $collection = new Collection([$appEvent, $pluginEvent, $failEvent]);
+
+            $this->scheduler->shouldReceive('dueEvents')
+                ->andReturn($collection);
+
+            return $this->scheduler;
+        });
+        $this->exec('schedule:run');
+
+        $this->assertExitSuccess();
+        $this->assertOutputContains('Executing [TestApp\\Command\\TestAppCommand]');
+        $this->assertOutputContains('Test App Command executed');
+        $this->assertOutputContains('Executing [TestPlugin\\Command\\TestPluginCommand]');
+        $this->assertOutputContains('Test Plugin Command executed');
+        $this->assertOutputContains('Executing [TestApp\\Command\\TestAppCommand@anonymous');
+        $this->assertErrorContains('Test Exception');
+    }
+
+    public function testRunMultipleCommandsAndSecondToLastOneFailsAndStopsExecution(): void
+    {
+        $this->mockService(Scheduler::class, function () {
+            $appEvent = new Event(new TestAppCommand(), []);
+            $pluginEvent = new Event(new TestPluginCommand(), []);
+            $failCommand = new class () extends TestAppCommand {
+                public function execute(Arguments $args, ConsoleIo $io): void
+                {
+                    throw new Exception('Test Exception');
+                }
+            };
+            $failEvent = new Event($failCommand, []);
+            $collection = new Collection([$appEvent, $failEvent, $pluginEvent]);
+
+            $this->scheduler->shouldReceive('dueEvents')
+                ->andReturn($collection);
+
+            $this->scheduler->getEventManager()->on('CakeScheduler.errorExecute', function (EventInterface $event) {
+                $event->setResult(Scheduler::SHOULD_STOP_EXECUTION);
+            });
+
+            return $this->scheduler;
+        });
+
+        $this->expectException(SchedulerStoppedException::class);
+        $this->expectExceptionMessage('Scheduler was stopped by event listener');
+        $this->exec('schedule:run');
+
+        $this->assertOutputContains('Executing [TestApp\\Command\\TestAppCommand]');
+        $this->assertOutputContains('Test App Command executed');
+        $this->assertOutputContains('Executing [TestApp\\Command\\TestAppCommand@anonymous');
+        $this->assertErrorContains('Test Exception');
+
+        $this->assertOutputNotContains('Executing [TestPlugin\\Command\\TestPluginCommand]');
+        $this->assertOutputNotContains('Test Plugin Command executed');
     }
 }


### PR DESCRIPTION
Fixes #12 

@crhdev would you be able to achieve your desired functionality with this behavior?

You basically have the ability to either stop scheduler execution on error or let it go on depending on the event and exception thrown