### PR TITLE
#13 add callable support

### DIFF
--- a/tests/TestCase/Command/ScheduleRunCommandTest.php
+++ b/tests/TestCase/Command/ScheduleRunCommandTest.php
@@ -231,4 +231,24 @@ class ScheduleRunCommandTest extends TestCase
         $this->assertOutputNotContains('Executing [TestPlugin\\Command\\TestPluginCommand]');
         $this->assertOutputNotContains('Test Plugin Command executed');
     }
+
+    public function testRunSingleCallable(): void
+    {
+        $this->mockService(Scheduler::class, function () {
+            $scheduler = new Scheduler(new Container());
+            $scheduler->execute(function ($a, $b, $c, ConsoleIo $io) {
+                $io->info('Sum');
+
+                return $a + $b + $c;
+            }, [1,2,3]);
+
+            return $scheduler;
+        });
+
+        $this->exec('schedule:run');
+
+        $this->assertExitSuccess();
+        $this->assertOutputContains('Executing [Cake\\Command\\Command@anonymous');
+        $this->assertOutputContains('<info>Sum</info>');
+    }
 }

--- a/tests/TestCase/Scheduler/SchedulerTest.php
+++ b/tests/TestCase/Scheduler/SchedulerTest.php
@@ -6,6 +6,7 @@ namespace CakeScheduler\Test\TestCase\Scheduler;
 use Cake\Chronos\Chronos;
 use Cake\Command\VersionCommand;
 use Cake\Console\Command\HelpCommand;
+use Cake\Console\ConsoleIo;
 use Cake\Core\Container;
 use Cake\TestSuite\TestCase;
 use CakeScheduler\Scheduler\Scheduler;
@@ -44,6 +45,17 @@ class SchedulerTest extends TestCase
         $events = $this->scheduler->dueEvents();
         $this->assertEquals(2, $events->count());
         Chronos::setTestNow('now');
+    }
+
+    public function testAddCallable(): void
+    {
+        $this->scheduler->execute(function ($a, $b, $c, ConsoleIo $io) {
+            $io->info('Sum');
+
+            return $a + $b + $c;
+        }, [1,2,3]);
+        $events = $this->scheduler->dueEvents();
+        $this->assertNotEmpty($events);
     }
 
     public function testAddUnknownCommand(): void


### PR DESCRIPTION
Fixes #13 

@crhdev I think this approach is a bit more backwards compatible.

Your proposed change in https://github.com/crhdev/cakephp-scheduler/commit/83b584123a7cd5412eb47060671180028aeb2278 changed a bit too much for my likeing.

My approach creates an anomyous command which can't be executed via `bin/cake` but still fits into how the rest of the scheduler system works.